### PR TITLE
fix: publish-workflow-tags

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,13 +7,11 @@ on:
 
 jobs:
   ci:
-    if: github.ref == 'refs/heads/main'
     uses: prosegrinder/.github/.github/workflows/poetry-ci.yaml@main
     secrets:
       VERSION_BUMP_TAG_TOKEN: "${{ secrets.VERSION_BUMP_TAG_TOKEN }}"
 
   publish:
-    if: github.ref == 'refs/heads/main'
     needs: ci
     uses: prosegrinder/.github/.github/workflows/poetry-publish.yaml@main
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,3 @@
-## v1.0.6 (2022-12-17)
-
-### Fix
-
-- publish-workflow (#16)
-- reverted to version 1.0.5
-- reset changelog to 1.0.5
-- removed concurrency
-- don't run on bump and removed needs
-- merge pull request #14 from prosegrinder/fix/relase-publish-workflows
-- republishing 1.0.6
-- added token for ci
-- removed skipping ci
-- reverted to 1.0.5
-- pass version bump token
-- incremental changelog by default
-- removed incremental changelog and for bump
-
 ## v1.0.5 (2022-12-13)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-version = "1.0.6"
+version = "1.0.5"
 tag_format = "v$version"
 update_changelog_on_bump = true
 changelog_incremental = true
@@ -10,7 +10,7 @@ version_files = [
 
 [tool.poetry]
 name = "syllables"
-version = "1.0.6"
+version = "1.0.5"
 description = "A Python package for estimating the number of syllables in a word."
 authors = ["David L. Day <david@davidlday.com>"]
 license = "GPLv3"


### PR DESCRIPTION
workflow was restricted to main, which would never run for tags.